### PR TITLE
Add basic luck tracking

### DIFF
--- a/src/main/java/fr/jachou/topluck/Topluck.java
+++ b/src/main/java/fr/jachou/topluck/Topluck.java
@@ -1,17 +1,42 @@
 package fr.jachou.topluck;
 
+import fr.jachou.topluck.command.TopLuckCommand;
+import fr.jachou.topluck.data.PlayerStats;
+import fr.jachou.topluck.listener.OreMineListener;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.*;
+
+/**
+ * Basic implementation of the TopLuck plugin tracking rare ore mining.
+ */
 public final class Topluck extends JavaPlugin {
+
+    private final Map<UUID, PlayerStats> statsMap = new HashMap<>();
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        Bukkit.getPluginManager().registerEvents(new OreMineListener(this), this);
+        PluginCommand cmd = getCommand("topluck");
+        if (cmd != null) {
+            cmd.setExecutor(new TopLuckCommand(this));
+        } else {
+            getLogger().warning("Command topluck not defined in plugin.yml");
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        statsMap.clear();
+    }
+
+    public PlayerStats getStats(UUID uuid) {
+        return statsMap.computeIfAbsent(uuid, PlayerStats::new);
+    }
+
+    public Collection<PlayerStats> getAllStats() {
+        return statsMap.values();
     }
 }

--- a/src/main/java/fr/jachou/topluck/command/TopLuckCommand.java
+++ b/src/main/java/fr/jachou/topluck/command/TopLuckCommand.java
@@ -1,0 +1,52 @@
+package fr.jachou.topluck.command;
+
+import fr.jachou.topluck.Topluck;
+import fr.jachou.topluck.data.PlayerStats;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+
+/**
+ * Displays simple statistics about rare ore mining.
+ */
+public class TopLuckCommand implements CommandExecutor {
+    private final Topluck plugin;
+
+    public TopLuckCommand(Topluck plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            showTop(sender);
+        } else {
+            showPlayer(sender, args[0]);
+        }
+        return true;
+    }
+
+    private void showTop(CommandSender sender) {
+        sender.sendMessage(ChatColor.AQUA + "-- Top Luck --");
+        plugin.getAllStats().stream()
+                .sorted(Comparator.comparingInt(PlayerStats::getRareOresMined).reversed())
+                .limit(10)
+                .forEach(stats -> {
+                    OfflinePlayer player = Bukkit.getOfflinePlayer(stats.getUuid());
+                    sender.sendMessage(ChatColor.YELLOW + player.getName() + ChatColor.WHITE + ": " + stats.getRareOresMined());
+                });
+    }
+
+    private void showPlayer(CommandSender sender, String name) {
+        OfflinePlayer target = Bukkit.getOfflinePlayer(name);
+        PlayerStats stats = plugin.getStats(target.getUniqueId());
+        sender.sendMessage(ChatColor.AQUA + "Stats for " + target.getName());
+        sender.sendMessage(ChatColor.YELLOW + "Rare ores mined: " + stats.getRareOresMined());
+    }
+}

--- a/src/main/java/fr/jachou/topluck/data/PlayerStats.java
+++ b/src/main/java/fr/jachou/topluck/data/PlayerStats.java
@@ -1,0 +1,27 @@
+package fr.jachou.topluck.data;
+
+import java.util.UUID;
+
+/**
+ * Simple in-memory statistics for a player.
+ */
+public class PlayerStats {
+    private final UUID uuid;
+    private int rareOresMined;
+
+    public PlayerStats(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public int getRareOresMined() {
+        return rareOresMined;
+    }
+
+    public void incrementRareOre() {
+        rareOresMined++;
+    }
+}

--- a/src/main/java/fr/jachou/topluck/listener/OreMineListener.java
+++ b/src/main/java/fr/jachou/topluck/listener/OreMineListener.java
@@ -1,0 +1,42 @@
+package fr.jachou.topluck.listener;
+
+import fr.jachou.topluck.Topluck;
+import fr.jachou.topluck.data.PlayerStats;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Listens for mining of rare ores and updates statistics.
+ */
+public class OreMineListener implements Listener {
+    private static final Set<Material> RARE_ORES = EnumSet.of(
+            Material.DIAMOND_ORE,
+            Material.DEEPSLATE_DIAMOND_ORE,
+            Material.ANCIENT_DEBRIS,
+            Material.EMERALD_ORE
+    );
+
+    private final Topluck plugin;
+
+    public OreMineListener(Topluck plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getBlock();
+        if (RARE_ORES.contains(block.getType())) {
+            PlayerStats stats = plugin.getStats(player.getUniqueId());
+            stats.incrementRareOre();
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,7 @@ name: Topluck
 version: '1.0-SNAPSHOT'
 main: fr.jachou.topluck.Topluck
 api-version: '1.21'
+commands:
+  topluck:
+    description: Display luck statistics
+    usage: /<command> [player]


### PR DESCRIPTION
## Summary
- add in-memory `PlayerStats` for basic data tracking
- track rare ore mining with `OreMineListener`
- expose `/topluck` command via `TopLuckCommand`
- wire listener and command in plugin and configure in `plugin.yml`

## Testing
- `mvn package` *(fails: Could not transfer artifact maven-resources-plugin from repo.maven.apache.org)*
- `mvn test` *(fails: Could not transfer artifact maven-resources-plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6854336b331c832eb36e42eff2e5109d