### PR TITLE
Add GUI menu for mining stats

### DIFF
--- a/src/main/java/fr/jachou/topluck/Topluck.java
+++ b/src/main/java/fr/jachou/topluck/Topluck.java
@@ -1,17 +1,42 @@
 package fr.jachou.topluck;
 
+import fr.jachou.topluck.command.TopLuckCommand;
+import fr.jachou.topluck.data.PlayerStats;
+import fr.jachou.topluck.listener.OreMineListener;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.*;
+
+/**
+ * Basic implementation of the TopLuck plugin tracking mining statistics.
+ */
 public final class Topluck extends JavaPlugin {
+
+    private final Map<UUID, PlayerStats> statsMap = new HashMap<>();
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        Bukkit.getPluginManager().registerEvents(new OreMineListener(this), this);
+        PluginCommand cmd = getCommand("topluck");
+        if (cmd != null) {
+            cmd.setExecutor(new TopLuckCommand(this));
+        } else {
+            getLogger().warning("Command topluck not defined in plugin.yml");
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        statsMap.clear();
+    }
+
+    public PlayerStats getStats(UUID uuid) {
+        return statsMap.computeIfAbsent(uuid, PlayerStats::new);
+    }
+
+    public Collection<PlayerStats> getAllStats() {
+        return statsMap.values();
     }
 }

--- a/src/main/java/fr/jachou/topluck/command/TopLuckCommand.java
+++ b/src/main/java/fr/jachou/topluck/command/TopLuckCommand.java
@@ -1,0 +1,66 @@
+package fr.jachou.topluck.command;
+
+import fr.jachou.topluck.Topluck;
+import fr.jachou.topluck.data.PlayerStats;
+import fr.jachou.topluck.menu.StatsMenu;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+
+/**
+ * Command entry point for the TopLuck plugin.
+ * Opens a GUI for players or prints text statistics for console usage.
+ */
+public class TopLuckCommand implements CommandExecutor {
+    private final Topluck plugin;
+
+    public TopLuckCommand(Topluck plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            if (sender instanceof Player player) {
+                new StatsMenu(plugin).open(player);
+            } else {
+                showTop(sender);
+            }
+        } else {
+            showPlayer(sender, args[0]);
+        }
+        return true;
+    }
+
+    private void showTop(CommandSender sender) {
+        sender.sendMessage(ChatColor.AQUA + "-- Top Luck --");
+        plugin.getAllStats().stream()
+                .sorted(Comparator.comparingInt(PlayerStats::getDiamondOresMined).reversed())
+                .limit(10)
+                .forEach(stats -> {
+                    OfflinePlayer player = Bukkit.getOfflinePlayer(stats.getUuid());
+                    sender.sendMessage(ChatColor.YELLOW + player.getName() + ChatColor.WHITE + ": " + stats.getDiamondOresMined());
+                });
+    }
+
+    private void showPlayer(CommandSender sender, String name) {
+        OfflinePlayer target = Bukkit.getOfflinePlayer(name);
+        PlayerStats stats = plugin.getStats(target.getUniqueId());
+        sender.sendMessage(ChatColor.AQUA + "Stats for " + target.getName());
+        sender.sendMessage(ChatColor.YELLOW + "Total blocks mined: " + stats.getTotalBlocksMined());
+        sender.sendMessage(ChatColor.AQUA + "Diamonds: " + stats.getDiamondOresMined() + format(stats.getDiamondOresMined(), stats));
+        sender.sendMessage(ChatColor.GREEN + "Emeralds: " + stats.getEmeraldOresMined() + format(stats.getEmeraldOresMined(), stats));
+        sender.sendMessage(ChatColor.GOLD + "Gold: " + stats.getGoldOresMined() + format(stats.getGoldOresMined(), stats));
+        sender.sendMessage(ChatColor.WHITE + "Iron: " + stats.getIronOresMined() + format(stats.getIronOresMined(), stats));
+    }
+
+    private String format(int count, PlayerStats stats) {
+        return String.format(" (%.2f%%)", stats.getPercentage(count));
+    }
+}

--- a/src/main/java/fr/jachou/topluck/data/PlayerStats.java
+++ b/src/main/java/fr/jachou/topluck/data/PlayerStats.java
@@ -1,0 +1,61 @@
+package fr.jachou.topluck.data;
+
+import java.util.UUID;
+
+/**
+ * Simple in-memory statistics for a player.
+ */
+public class PlayerStats {
+    private final UUID uuid;
+    private int totalBlocksMined;
+    private int diamondOresMined;
+    private int emeraldOresMined;
+    private int goldOresMined;
+    private int ironOresMined;
+
+    public PlayerStats(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public int getTotalBlocksMined() {
+        return totalBlocksMined;
+    }
+
+    public int getDiamondOresMined() {
+        return diamondOresMined;
+    }
+
+    public int getEmeraldOresMined() {
+        return emeraldOresMined;
+    }
+
+    public int getGoldOresMined() {
+        return goldOresMined;
+    }
+
+    public int getIronOresMined() {
+        return ironOresMined;
+    }
+
+    public void incrementBlock(org.bukkit.Material type) {
+        totalBlocksMined++;
+        switch (type) {
+            case DIAMOND_ORE,
+                    DEEPSLATE_DIAMOND_ORE -> diamondOresMined++;
+            case EMERALD_ORE -> emeraldOresMined++;
+            case GOLD_ORE, DEEPSLATE_GOLD_ORE, NETHER_GOLD_ORE -> goldOresMined++;
+            case IRON_ORE, DEEPSLATE_IRON_ORE -> ironOresMined++;
+            default -> {
+            }
+        }
+    }
+
+    public double getPercentage(int count) {
+        if (totalBlocksMined == 0) return 0.0D;
+        return (double) count * 100.0D / totalBlocksMined;
+    }
+}

--- a/src/main/java/fr/jachou/topluck/listener/OreMineListener.java
+++ b/src/main/java/fr/jachou/topluck/listener/OreMineListener.java
@@ -1,0 +1,30 @@
+package fr.jachou.topluck.listener;
+
+import fr.jachou.topluck.Topluck;
+import fr.jachou.topluck.data.PlayerStats;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.util.UUID;
+
+/**
+ * Listens for block breaking events and updates statistics.
+ */
+public class OreMineListener implements Listener {
+    private final Topluck plugin;
+
+    public OreMineListener(Topluck plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getBlock();
+        PlayerStats stats = plugin.getStats(player.getUniqueId());
+        stats.incrementBlock(block.getType());
+    }
+}

--- a/src/main/java/fr/jachou/topluck/menu/StatsMenu.java
+++ b/src/main/java/fr/jachou/topluck/menu/StatsMenu.java
@@ -1,0 +1,58 @@
+package fr.jachou.topluck.menu;
+
+import fr.jachou.topluck.Topluck;
+import fr.jachou.topluck.data.PlayerStats;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Simple GUI to display mining statistics for online players.
+ */
+public class StatsMenu {
+
+    private final Topluck plugin;
+
+    public StatsMenu(Topluck plugin) {
+        this.plugin = plugin;
+    }
+
+    public void open(Player viewer) {
+        Collection<? extends Player> players = Bukkit.getOnlinePlayers();
+        int size = Math.max(9, ((players.size() - 1) / 9 + 1) * 9);
+        Inventory inv = Bukkit.createInventory(null, size, ChatColor.DARK_GREEN + "TopLuck Stats");
+        int index = 0;
+        for (Player p : players) {
+            PlayerStats stats = plugin.getStats(p.getUniqueId());
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            if (meta != null) {
+                meta.setOwningPlayer(p);
+                meta.setDisplayName(ChatColor.YELLOW + p.getName());
+                List<String> lore = new ArrayList<>();
+                lore.add(ChatColor.GRAY + "Total mined: " + stats.getTotalBlocksMined());
+                lore.add(ChatColor.AQUA + "Diamonds: " + stats.getDiamondOresMined() + formatPercent(stats.getDiamondOresMined(), stats));
+                lore.add(ChatColor.GREEN + "Emeralds: " + stats.getEmeraldOresMined() + formatPercent(stats.getEmeraldOresMined(), stats));
+                lore.add(ChatColor.GOLD + "Gold: " + stats.getGoldOresMined() + formatPercent(stats.getGoldOresMined(), stats));
+                lore.add(ChatColor.WHITE + "Iron: " + stats.getIronOresMined() + formatPercent(stats.getIronOresMined(), stats));
+                meta.setLore(lore);
+                head.setItemMeta(meta);
+            }
+            inv.setItem(index++, head);
+        }
+        viewer.openInventory(inv);
+    }
+
+    private String formatPercent(int count, PlayerStats stats) {
+        double pct = stats.getPercentage(count);
+        return String.format(" (%.2f%%)", pct);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,7 @@ name: Topluck
 version: '1.0-SNAPSHOT'
 main: fr.jachou.topluck.Topluck
 api-version: '1.21'
+commands:
+  topluck:
+    description: Show mining statistics menu
+    usage: /<command> [player]


### PR DESCRIPTION
## Summary
- add StatsMenu inventory for modern GUI
- expand PlayerStats to track ore counts and total mining
- update command to open GUI and show detailed stats
- capture block breaks to update statistics
- tweak plugin description in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: maven-resources-plugin resolution)*
- `mvn -q test` *(fails: maven-resources-plugin resolution)*

------
https://chatgpt.com/codex/tasks/task_e_6854336b331c832eb36e42eff2e5109d